### PR TITLE
Fix compile error with arm-none-eabi-gcc 9.2.0 (@ArchLinux)

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -9,6 +9,8 @@
  * See the file COPYING for more details, or visit <http://unlicense.org>.
  */
 
+#include <limits.h>
+
 void *memset(void *s, int c, size_t n)
 {
     char *p = s;
@@ -119,7 +121,7 @@ size_t strnlen(const char *s, size_t maxlen)
 
 int strcmp(const char *s1, const char *s2)
 {
-    return strncmp(s1, s2, ~0);
+    return strncmp(s1, s2, INT_MAX);
 }
 
 int strncmp(const char *s1, const char *s2, size_t n)


### PR DESCRIPTION
This fixes the following compile error with with arm-none-eabi-gcc 9.2.0 (@ArchLinux)

CC util.o
util.c: In function 'strcmp':
util.c:122:12: error: 'strncmp' specified bound 4294967295 exceeds maximum object size 2147483647 [-Werror=stringop-overflow=]
  122 |     return strncmp(s1, s2, ~0);
      |            ^~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
