### PR TITLE
The previous (modified) commit created new problems on Arch Linux arm-eabi-gcc-9.2.0

### DIFF
--- a/inc/cdc_acm_protocol.h
+++ b/inc/cdc_acm_protocol.h
@@ -72,7 +72,7 @@
  */
 
 /* CMD_GET_INFO, index 0 */
-struct __packed gw_info {
+struct packed gw_info {
     uint8_t fw_major;
     uint8_t fw_minor;
     uint8_t max_index;
@@ -81,19 +81,19 @@ struct __packed gw_info {
 };
 
 /* CMD_READ_FLUX */
-struct __packed gw_read_flux {
+struct packed gw_read_flux {
     uint8_t nr_idx; /* default: 2 */
 };
 
 /* CMD_WRITE_FLUX */
-struct __packed gw_write_flux {
+struct packed gw_write_flux {
     uint32_t index_delay_ticks; /* default: 0 */
     uint8_t terminate_at_index; /* default: 0 */
 };
 
 /* CMD_{GET,SET}_PARAMS, index 0 */
 #define PARAMS_DELAYS 0
-struct __packed gw_delay {
+struct packed gw_delay {
     uint16_t select_delay; /* usec */
     uint16_t step_delay;   /* usec */
     uint16_t seek_settle;  /* msec */

--- a/inc/intrinsics.h
+++ b/inc/intrinsics.h
@@ -19,8 +19,9 @@ struct exception_frame {
 /* Force a compilation error if condition is true */
 #define BUILD_BUG_ON(cond) ({ _Static_assert(!(cond), "!(" #cond ")"); })
 
-#define __aligned(x) __attribute__((aligned(x)))
-#define __packed __attribute((packed))
+#define aligned(x) __attribute__((aligned(x)))
+#define packed __attribute((packed))
+
 #define always_inline __inline__ __attribute__((always_inline))
 #define noinline __attribute__((noinline))
 

--- a/src/usb/cdc_acm.c
+++ b/src/usb/cdc_acm.c
@@ -17,7 +17,7 @@
 #define CDC_SET_CONTROL_LINE_STATE 0x22
 #define CDC_SEND_BREAK 0x23
 
-static struct __packed line_coding {
+static struct packed line_coding {
     uint32_t baud;
     uint8_t nr_stop;
     uint8_t parity;

--- a/src/usb/config.c
+++ b/src/usb/config.c
@@ -9,7 +9,7 @@
  * See the file COPYING for more details, or visit <http://unlicense.org>.
  */
 
-const uint8_t device_descriptor[] __aligned(2) = {
+const uint8_t device_descriptor[] aligned(2) = {
     18,        /* Length */
     DESC_DEVICE, /* Descriptor Type */
     0x10,0x01, /* USB 1.1 */
@@ -22,7 +22,7 @@ const uint8_t device_descriptor[] __aligned(2) = {
     1          /* Number of configurations */
 };
 
-const uint8_t config_descriptor[] __aligned(2) = {
+const uint8_t config_descriptor[] aligned(2) = {
     0x09, /* 0 bLength */
     DESC_CONFIGURATION, /* 1 bDescriptortype - Configuration*/
     0x43, 0x00, /* 2 wTotalLength */

--- a/src/usb/defs.h
+++ b/src/usb/defs.h
@@ -35,7 +35,7 @@
 
 #define USB_CLASS_CDC_DATA 0x0a
 
-struct __packed usb_device_request {
+struct packed usb_device_request {
     uint8_t bmRequestType;
     uint8_t bRequest;
     uint16_t wValue;


### PR DESCRIPTION
The previous (modified) commit created new problems on Arch Linux arm-eabi-gcc-9.2.0

This patch attempts to fix this while retaining the defines in intrinsics.h that should (only) be found in the compiler supplied includes - maybe they are not present on older compilers ?

CC board.o
In file included from /tmp/keirf-Greaseweazle.git/inc/decls.h:21,
                 from <command-line>:
/tmp/keirf-Greaseweazle.git/inc/intrinsics.h:22: error: "__aligned" redefined [-Werror]
   22 | #define __aligned(x) __attribute__((aligned(x)))
      | 
In file included from /usr/arm-none-eabi/include/limits.h:5,
                 from /usr/lib/gcc/arm-none-eabi/9.2.0/include-fixed/limits.h:194,
                 from /usr/lib/gcc/arm-none-eabi/9.2.0/include-fixed/syslimits.h:7,
                 from /usr/lib/gcc/arm-none-eabi/9.2.0/include-fixed/limits.h:34,
                 from /tmp/keirf-Greaseweazle.git/inc/decls.h:16,
                 from <command-line>:
/usr/arm-none-eabi/include/sys/cdefs.h:248: note: this is the location of the previous definition
  248 | #define __aligned(x) __attribute__((__aligned__(x)))
      | 
In file included from /tmp/keirf-Greaseweazle.git/inc/decls.h:21,
                 from <command-line>:
/tmp/keirf-Greaseweazle.git/inc/intrinsics.h:23: error: "__packed" redefined [-Werror]
   23 | #define __packed __attribute((packed))
      | 
In file included from /usr/arm-none-eabi/include/limits.h:5,
                 from /usr/lib/gcc/arm-none-eabi/9.2.0/include-fixed/limits.h:194,
                 from /usr/lib/gcc/arm-none-eabi/9.2.0/include-fixed/syslimits.h:7,
                 from /usr/lib/gcc/arm-none-eabi/9.2.0/include-fixed/limits.h:34,
                 from /tmp/keirf-Greaseweazle.git/inc/decls.h:16,
                 from <command-line>:
/usr/arm-none-eabi/include/sys/cdefs.h:247: note: this is the location of the previous definition
  247 | #define __packed __attribute__((__packed__))
      | 
cc1: all warnings being treated as errors
make[2]: *** [/tmp/keirf-Greaseweazle.git/Rules.mk:59: board.o] Error 1

