### PR TITLE
Patches to allow building on Windows

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -3,8 +3,6 @@ CC = $(TOOL_PREFIX)gcc
 OBJCOPY = $(TOOL_PREFIX)objcopy
 LD = $(TOOL_PREFIX)ld
 
-PYTHON = python3
-
 ifneq ($(VERBOSE),1)
 TOOL_PREFIX := @$(TOOL_PREFIX)
 endif

--- a/blinky_test/Makefile
+++ b/blinky_test/Makefile
@@ -1,4 +1,4 @@
-RPATH = ../src
+RPATH = $(ROOT)/src
 
 OBJS += vectors.o
 OBJS += cortex.o

--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -1,4 +1,4 @@
-RPATH = ../src
+RPATH = $(ROOT)/src
 
 OBJS += board.o
 OBJS += build_info.o

--- a/bootloader/usb/Makefile
+++ b/bootloader/usb/Makefile
@@ -1,4 +1,4 @@
-RPATH = ../../src/usb
+RPATH = $(ROOT)/src/usb
 
 OBJS += config.o
 OBJS += core.o


### PR DESCRIPTION
Hi Keir, I've got building working on Windows natively. It appears Windows gnu make (3.81) doesn't pass on make variables to sub process makes, so I've added them explicitly.
I've also allowed the use of different names for the Python and Zip executables in Windows.
The final change is replacing relative paths (..) in RPATH with $(ROOT) etc.
I've also checked that it still works on Ubuntu!