### PR TITLE
Present list of supported image types when asking for one that doesn't exist

### DIFF
--- a/scripts/greaseweazle/tools/util.py
+++ b/scripts/greaseweazle/tools/util.py
@@ -171,7 +171,7 @@ def get_image_class(name):
     else:
         _, ext = os.path.splitext(name)
         error.check(ext.lower() in image_types,
-                    "%s: Unrecognised file suffix '%s'" % (name, ext))
+                    "%s: Unrecognised file suffix '%s' (known suffixes: %s)" % (name, ext, ', '.join(map(lambda t: t[0], image_types))))
         typename = image_types[ext.lower()]
     mod = importlib.import_module('greaseweazle.image.' + typename.lower())
     return mod.__dict__[typename]

--- a/scripts/greaseweazle/tools/util.py
+++ b/scripts/greaseweazle/tools/util.py
@@ -171,7 +171,7 @@ def get_image_class(name):
     else:
         _, ext = os.path.splitext(name)
         error.check(ext.lower() in image_types,
-                    "%s: Unrecognised file suffix '%s' (known suffixes: %s)" % (name, ext, ', '.join(map(lambda t: t[0], image_types))))
+                    "%s: Unrecognised file suffix '%s' (known suffixes: %s)" % (name, ext, ', '.join(image_types)))
         typename = image_types[ext.lower()]
     mod = importlib.import_module('greaseweazle.image.' + typename.lower())
     return mod.__dict__[typename]


### PR DESCRIPTION
I figured from the posts in #103 that it would be worthwhile to expand the error message a bit.

Output now looks something like this:
```
% ./gw read --drive 0 foo.fdi
** FATAL ERROR:
foo.fdi: Unrecognised file suffix '.fdi' (known suffixes: .adf, .scp, .hfe, .ima, .img, .ipf, .dsk, .raw)
```

If there's some changes you'd like to have (for instance, the error message generation is now the longest line in the file) please let me know.