### PR TITLE
Disable stdout buffering on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@ scripts/greaseweazle/optimised/optimised*
 scripts/c_ext/build/
 scripts/c_ext/*.egg-info/
 greaseweazle-tools-*
-scripts/setup.sh
-scripts/setup.sh
+

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ scripts/greaseweazle/optimised/optimised*
 scripts/c_ext/build/
 scripts/c_ext/*.egg-info/
 greaseweazle-tools-*
+scripts/setup.sh
+scripts/setup.sh

--- a/scripts/gw.py
+++ b/scripts/gw.py
@@ -12,6 +12,13 @@
 import sys, time
 import importlib
 
+# NSB 2nd Feb 2022
+# Disable buffered stdout output so that processes on Windows
+# can receive line-by-line output
+import os
+if os.environ.get('OS','') == 'Windows_NT':
+    sys.stdout = sys.stderr
+
 from greaseweazle import version
 if hasattr(version, 'commit'):
     print("""*** TEST/PRE-RELEASE: commit %s


### PR DESCRIPTION
So that Windows processes can receive line-by-line output, for GUI purposes