### PR TITLE
Fix typos in help text

### DIFF
--- a/scripts/greaseweazle/tools/util.py
+++ b/scripts/greaseweazle/tools/util.py
@@ -47,9 +47,9 @@ TSPEC: Colon-separated list of:
   h=SET               :: Set of heads (sides) to access
   step=[0-9]          :: # physical head steps between cylinders
   hswap               :: Swap physical drive heads
-  h[01].off=[+-][0-9] :: Physical cylkinder offsets per head
+  h[01].off=[+-][0-9] :: Physical cylinder offsets per head
   SET is a comma-separated list of integers and integer ranges
-  eg. 'c=0-7,9-12:h=0-1'
+  e.g. 'c=0-7,9-12:h=0-1'
 """
 
 # Returns time period in seconds (float)


### PR DESCRIPTION
Unless "cylkinders" are some sort of strange unit I've never heard of, that is :smile: The e.g. doesn't really matter but I figured I'd add it in there while I was at it.