### PR TITLE
Add Apple floppy types

### DIFF
--- a/scripts/greaseweazle/tools/clean.py
+++ b/scripts/greaseweazle/tools/clean.py
@@ -38,7 +38,7 @@ def main(argv):
     parser = util.ArgumentParser(usage='%(prog)s [options]')
     parser.add_argument("--device", help="device name (COM/serial port)")
     parser.add_argument("--drive", type=util.drive_letter, default='A',
-                        help="drive to write (A,B,0,1,2)")
+                        help="drive to read (A,B,0,1,2,APPLE2,APPLE2_QUARTERTRACK)")
     parser.add_argument("--cyls", type=int, default=80, metavar="N",
                         help="number of drive cylinders")
     parser.add_argument("--passes", type=int, default=3, metavar="N",

--- a/scripts/greaseweazle/tools/erase.py
+++ b/scripts/greaseweazle/tools/erase.py
@@ -42,7 +42,7 @@ def main(argv):
                                  epilog=epilog)
     parser.add_argument("--device", help="device name (COM/serial port)")
     parser.add_argument("--drive", type=util.drive_letter, default='A',
-                        help="drive to write (A,B,0,1,2)")
+                        help="drive to read (A,B,0,1,2,APPLE2,APPLE2_QUARTERTRACK)")
     parser.add_argument("--tracks", type=util.TrackSet, metavar="TSPEC",
                         help="which tracks to erase")
     parser.add_argument("--hfreq", action="store_true",

--- a/scripts/greaseweazle/tools/pin.py
+++ b/scripts/greaseweazle/tools/pin.py
@@ -50,7 +50,7 @@ def pin_get(argv):
     parser = util.ArgumentParser(usage='%(prog)s [options] pin')
     parser.add_argument("--device", help="device name (COM/serial port)")
     parser.add_argument("--drive", type=util.drive_letter, default='A',
-                        help="drive to read (A,B,0,1,2)")
+                        help="drive to read (A,B,0,1,2,APPLE2,APPLE2_QUARTERTRACK)")
     parser.add_argument("pin", type=int, help="pin number")
     parser.description = description
     parser.prog += ' pin get'

--- a/scripts/greaseweazle/tools/read.py
+++ b/scripts/greaseweazle/tools/read.py
@@ -158,7 +158,7 @@ def main(argv):
                                  epilog=epilog)
     parser.add_argument("--device", help="device name (COM/serial port)")
     parser.add_argument("--drive", type=util.drive_letter, default='A',
-                        help="drive to read (A,B,0,1,2)")
+                        help="drive to read (A,B,0,1,2,APPLE2,APPLE2_QUARTERTRACK)")
     parser.add_argument("--format", help="disk format (output is converted unless --raw)")
     parser.add_argument("--revs", type=int, metavar="N",
                         help="number of revolutions to read per track")

--- a/scripts/greaseweazle/tools/rpm.py
+++ b/scripts/greaseweazle/tools/rpm.py
@@ -43,7 +43,7 @@ def main(argv):
     parser = util.ArgumentParser(usage='%(prog)s [options]')
     parser.add_argument("--device", help="greaseweazle device name")
     parser.add_argument("--drive", type=util.drive_letter, default='A',
-                        help="drive to read (A,B,0,1,2)")
+                        help="drive to read (A,B,0,1,2,APPLE2,APPLE2_QUARTERTRACK)")
     parser.add_argument("--nr", type=int, default=1, metavar="N",
                         help="number of iterations")
     parser.description = description

--- a/scripts/greaseweazle/tools/seek.py
+++ b/scripts/greaseweazle/tools/seek.py
@@ -28,7 +28,7 @@ def main(argv):
     parser = util.ArgumentParser(usage='%(prog)s [options] cylinder')
     parser.add_argument("--device", help="device name (COM/serial port)")
     parser.add_argument("--drive", type=util.drive_letter, default='A',
-                        help="drive to read (A,B,0,1,2)")
+                        help="drive to read (A,B,0,1,2,APPLE2,APPLE2_QUARTERTRACK)")
     parser.add_argument("--force", action="store_true",
                         help="allow extreme cylinders with no prompt")
     parser.add_argument("--motor-on", action="store_true",

--- a/scripts/greaseweazle/tools/util.py
+++ b/scripts/greaseweazle/tools/util.py
@@ -78,7 +78,9 @@ def drive_letter(letter):
         'B': (USB.BusType.IBMPC, 1),
         '0': (USB.BusType.Shugart, 0),
         '1': (USB.BusType.Shugart, 1),
-        '2': (USB.BusType.Shugart, 2)
+        '2': (USB.BusType.Shugart, 2),
+        'APPLE2': (USB.BusType.Apple2, 0),
+        'APPLE2_QUARTERTRACK': (USB.BusType.Apple2QuarterTrack, 0),
     }
     if not letter.upper() in types:
         raise argparse.ArgumentTypeError("invalid drive letter: '%s'" % letter)

--- a/scripts/greaseweazle/tools/write.py
+++ b/scripts/greaseweazle/tools/write.py
@@ -173,7 +173,7 @@ def main(argv):
                                  epilog=epilog)
     parser.add_argument("--device", help="device name (COM/serial port)")
     parser.add_argument("--drive", type=util.drive_letter, default='A',
-                        help="drive to write (A,B,0,1,2)")
+                        help="drive to read (A,B,0,1,2,APPLE2,APPLE2_QUARTERTRACK)")
     parser.add_argument("--format", help="disk format")
     parser.add_argument("--tracks", type=util.TrackSet, metavar="TSPEC",
                         help="which tracks to write")

--- a/scripts/greaseweazle/usb.py
+++ b/scripts/greaseweazle/usb.py
@@ -120,9 +120,11 @@ class Params:
 
 ## Cmd.SetBusType values
 class BusType:
-    Invalid         = 0
-    IBMPC           = 1
-    Shugart         = 2
+    Invalid            = 0
+    IBMPC              = 1
+    Shugart            = 2
+    Apple2             = 3
+    Apple2QuarterTrack = 4
 
 
 ## Flux read stream opcodes, preceded by 0xFF byte


### PR DESCRIPTION
Hi! For Adafruit, it's my intention to extend the Greasweazle protocol so that it can support Apple II-style floppy drive interfaces. I'm new to Apple II disk reading & preservation so I will have a lot to learn.

Compared to a PC or Shugart interface, there are some notable differences:
 * Instead of step & direction, there are 4 "winding activation" signals. The GW-compatible hardware will generate these outputs on hardware-defined pins.
 * While the track spacing is the same as a PC "double density" disk, the read/write head can be positioned 1/4 as finely as a single track spacing. Apparently, this is used in copy protected Apple II software, similar to fat/half tracks in Commodore 64, just worse.
 * There is no "track 0" sensor, instead the "bang your head into a wall" algorithm is used.
 * There is no index sensor, though we anticipate recommending a reflective IR sensor modification and are OK if it is required
 * The 'write' signal is different than for a PC drive: a flux reversal is written when the write data line is inverted, rather than when it is pulsed.

Consequently, I would like to allocate two new numbers for 'bus type': Apple2 and Apple2QuarterTrack. These would be accessed with `--drive APPLE2` and `--drive APPLE2_QUARTERTRACK` in the GW commandline.

Together with pending changes in fluxengine, 