### PR TITLE
Add Atari 90kB format

### DIFF
--- a/scripts/greaseweazle/codec/formats.py
+++ b/scripts/greaseweazle/codec/formats.py
@@ -151,6 +151,16 @@ class Format_IBM_1200(Format):
         self.default_revs = m.default_revs
         super().__init__()
 
+class Format_Atari_90(Format):
+    img_compatible = True
+    default_trackset = 'c=0-39:h=0:step=2'
+    max_trackset = 'c=0-41:h=0:step=2'
+    def __init__(self):
+        import greaseweazle.codec.ibm.fm as m
+        self.fmt = m.Atari_90
+        self.default_revs = m.default_revs
+        super().__init__()
+
 class Format_AtariST_360(Format):
     img_compatible = True
     default_trackset = 'c=0-79:h=0'
@@ -226,6 +236,7 @@ formats = OrderedDict({
     'acorn.adfs.1600': Format_Acorn_ADFS_1600,
     'amiga.amigados': Format_Amiga_AmigaDOS_DD,
     'amiga.amigados_hd': Format_Amiga_AmigaDOS_HD,
+    'atari.90': Format_Atari_90,
     'atarist.360': Format_AtariST_360,
     'atarist.400': Format_AtariST_400,
     'atarist.440': Format_AtariST_440,

--- a/scripts/greaseweazle/codec/ibm/fm.py
+++ b/scripts/greaseweazle/codec/ibm/fm.py
@@ -320,6 +320,16 @@ class Acorn_DFS(IBM_FM_Predefined):
     sz     = 1
     cskew  = 3
 
+class Atari_90(IBM_FM_Predefined):
+    time_per_rev = 0.2
+    clock = 4e-6
+
+    gap_1 = 6
+    gap_3 = 17
+    nsec  = 18
+    id0   = 0
+    sz    = 0
+    cskew = 3
 
 encode_list = []
 for x in range(256):


### PR DESCRIPTION
This is the format used by the Atari 810, commonly used with Atari 800 computers.

I have just a single floppy in this format, and with this patch and Adafruit's generic GW compatible it almost reads.. but consistently has errors in certain sectors.

```
T39.0: IBM FM (17/18 sectors) - 1 sectors missing - Giving up
Cyl-> 0         1         2         3
H. S: 0123456789012345678901234567890123456789
0. 0: X.....X.....X.....X.....X.....X.....X...
0. 1: ........................................
0. 2: ........................................
0. 3: .X.....X.....X.....X.....X.....X.....X..
0. 4: ........................................
0. 5: ........................................
0. 6: ..X.....X.....X.....X.....X.....X.....X.
0. 7: ........................................
0. 8: ........................................
0. 9: ...X.....X.....X.....X.....X.....X.....X
0.10: ........................................
0.11: ........................................
0.12: ....X.....X.....XX....X.....X.....X.....
0.13: ........................................
0.14: ........................................
0.15: .....X.....X.....X.....X.....X.....X....
0.16: ........................................
0.17: ........................................
Found 679 sectors of 720 (94%)
```

~~This also fixes a bug that can be seen if an IDAM marker occurs very close to the end of recorded flux for a track. This error popped up for me frequently while working on this particular floppy.~~