### PR TITLE
Add more information to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Greaseweazle: Tools
+# Greaseweazle Host Tools
 
 *Tools for accessing a floppy drive at the raw flux level.*
 
@@ -6,22 +6,42 @@
 ![Downloads Badge][downloads-badge]
 ![Version Badge][version-badge]
 
-This repository contains the host tools for controlling a Greaseweazle
-USB device, including source code and binary releases. Find the device
-firmware repository [here][firmware].
+This repository contains the host tools for controlling a Greaseweazle,
+a free and open source USB device capable of reading raw data from
+nearly any type of floppy disk.
 
-### [Purchase a ready-made Greaseweazle][rmb]
-### [Download Greaseweazle][Downloads]
-### [Read the GitHub Wiki](https://github.com/keirf/greaseweazle/wiki)
+For more info, see the following links:
 
-### Redistribution
+* [Download binaries][Downloads]
+* [Purchase a ready-made Greaseweazle][rmb]
+* [Read the GitHub wiki](https://github.com/keirf/greaseweazle/wiki)
+* [Greaseweazle firmware repository][firmware]
+
+## Installation
+
+On macOS and Linux, download the [latest source code]
+and install using `pip`:
+`python3 -m pip install greaseweazle-*.zip`.
+
+See the [software installation wiki page][siwp] for more detailed
+installation instructions for your platform.
+
+## Usage
+
+Type `gw --help` for on-line help.
+
+Read the [GitHub wiki](https://github.com/keirf/greaseweazle/wiki)
+for more detailed usage instructions.
+
+## Redistribution
 
 Greaseweazle source code, and all binary releases, are freely redistributable
 in any form. Please see the [license](COPYING).
 
 [firmware]: https://github.com/keirf/greaseweazle-firmware
 [rmb]: https://github.com/keirf/greaseweazle/wiki/Ready-Made-Boards
-[Downloads]: https://github.com/keirf/greaseweazle/wiki/Downloads
+[Downloads]: https://github.com/keirf/greaseweazle/wiki/Download-Host-Tools
+[siwp]: https://github.com/keirf/greaseweazle/wiki/Software-Installation
 
 [ci-badge]: https://github.com/keirf/greaseweazle/workflows/CI/badge.svg
 [downloads-badge]: https://img.shields.io/github/downloads/keirf/greaseweazle/total


### PR DESCRIPTION
Basically:

* Add basic installation and usage instructions that make clear the fact Greaseweazle documentation is stored in the wiki as opposed to on-line (in-repo) files
* Format the links to be regular text as opposed to headings so that screen readers and machines can better understand
* Update links to reflect current wiki pages
* Add a little bit of info about what a Greaseweazle is, for those who stumble upon the repo with no prior knowledge