### PR TITLE
Add XDF image format for Sharp X68000.

### DIFF
--- a/src/greaseweazle/image/xdf.py
+++ b/src/greaseweazle/image/xdf.py
@@ -1,0 +1,15 @@
+# greaseweazle/image/acorn.py
+#
+# Written & released by Keir Fraser <keir.xen@gmail.com>
+#
+# This is free and unencumbered software released into the public domain.
+# See the file COPYING for more details, or visit <http://unlicense.org>.
+
+from greaseweazle.image.img import IMG
+
+class XDF(IMG):
+    default_format = 'pc98.hd'
+
+# Local variables:
+# python-indent: 4
+# End:

--- a/src/greaseweazle/tools/util.py
+++ b/src/greaseweazle/tools/util.py
@@ -236,7 +236,8 @@ image_types = OrderedDict(
       '.sf7': 'SF7',
       '.scp': 'SCP',
       '.ssd': ('SSD','acorn'),
-      '.st' : 'IMG' })
+      '.st' : 'IMG',
+      '.xdf': 'XDF' })
 
 def get_image_class(name):
     _, ext = os.path.splitext(name)


### PR DESCRIPTION
This is just a bare image where the format is known.
