### PR TITLE
Add HDM image format for NEC PC-98.

### DIFF
--- a/src/greaseweazle/image/hdm.py
+++ b/src/greaseweazle/image/hdm.py
@@ -1,0 +1,15 @@
+# greaseweazle/image/acorn.py
+#
+# Written & released by Keir Fraser <keir.xen@gmail.com>
+#
+# This is free and unencumbered software released into the public domain.
+# See the file COPYING for more details, or visit <http://unlicense.org>.
+
+from greaseweazle.image.img import IMG
+
+class HDM(IMG):
+    default_format = 'pc98.hd'
+
+# Local variables:
+# python-indent: 4
+# End:

--- a/src/greaseweazle/tools/util.py
+++ b/src/greaseweazle/tools/util.py
@@ -227,6 +227,7 @@ image_types = OrderedDict(
       '.d81': 'D81',
       '.dsd': ('DSD','acorn'),
       '.dsk': 'EDSK',
+      '.hdm': 'HDM',
       '.hfe': 'HFE',
       '.ima': 'IMG',
       '.img': 'IMG',


### PR DESCRIPTION
Technically this extension belongs to a whole series of formats:

https://github.com/keirf/FlashFloppy/issues/198

However, I have only been able to find HDM, so I can't verify that
the others are correct. As a result I'm only adding HDM.
