### PR TITLE
Rename pc98.dd and pc98.hd formats.

### DIFF
--- a/src/greaseweazle/codec/formats.py
+++ b/src/greaseweazle/codec/formats.py
@@ -281,23 +281,23 @@ class Format_PC98_2D(Format):
         self.default_revs = m.default_revs
         super().__init__()
 
-class Format_PC98_DD(Format):
+class Format_PC98_2DD(Format):
     img_compatible = True
     default_trackset = 'c=0-76:h=0-1'
     max_trackset = 'c=0-81:h=0-1'
     def __init__(self):
         import greaseweazle.codec.ibm.mfm as m
-        self.fmt = m.PC98_DD
+        self.fmt = m.PC98_2DD
         self.default_revs = m.default_revs
         super().__init__()
 
-class Format_PC98_HD(Format):
+class Format_PC98_2HD(Format):
     img_compatible = True
     default_trackset = 'c=0-76:h=0-1'
     max_trackset = 'c=0-81:h=0-1'
     def __init__(self):
         import greaseweazle.codec.ibm.mfm as m
-        self.fmt = m.PC98_HD
+        self.fmt = m.PC98_2HD
         self.default_revs = m.default_revs
         super().__init__()
 
@@ -354,8 +354,8 @@ formats = OrderedDict({
     'ibm.dmf': Format_IBM_1680,
     'ibm.2880': Format_IBM_2880,
     'pc98.2d': Format_PC98_2D,
-    'pc98.dd': Format_PC98_DD,
-    'pc98.hd': Format_PC98_HD,
+    'pc98.2dd': Format_PC98_2DD,
+    'pc98.2hd': Format_PC98_2HD,
     'pc98.2hs': Format_PC98_2HS,
     'sega.sf7000': Format_Sega_SF7000,
 })

--- a/src/greaseweazle/codec/ibm/mfm.py
+++ b/src/greaseweazle/codec/ibm/mfm.py
@@ -512,14 +512,14 @@ class PC98_2D(IBM_MFM_720):
     nsec  = 8
     sz    = 2
 
-class PC98_DD(IBM_MFM_1200):
+class PC98_2DD(IBM_MFM_1200):
 
     clock = 2e-6
     gap_3 = 57
     nsec  = 8
     sz    = 2
 
-class PC98_HD(IBM_MFM_1200):
+class PC98_2HD(IBM_MFM_1200):
 
     gap_3 = 116
     nsec  = 8

--- a/src/greaseweazle/image/d88.py
+++ b/src/greaseweazle/image/d88.py
@@ -27,7 +27,7 @@ class D88(IMG):
             header = f.read(32)
             (disk_name, terminator, write_protect, media_flag, disk_size) = struct.unpack('<16sB9xBBL', header)
             if media_flag == 0x20:
-                format_str = 'pc98.hd'
+                format_str = 'pc98.2hd'
             elif media_flag == 0x00:
                 format_str = 'pc98.2d'
             else:

--- a/src/greaseweazle/image/dim.py
+++ b/src/greaseweazle/image/dim.py
@@ -27,7 +27,7 @@ class DIM(IMG):
                         "DIM: Not a DIM file.")
             (media_byte,) = struct.unpack('B255x', header)
             if media_byte == 0:
-                format_str = 'pc98.hd'
+                format_str = 'pc98.2hd'
             elif media_byte == 1:
                 format_str = 'pc98.2hs'
             else:

--- a/src/greaseweazle/image/fdi.py
+++ b/src/greaseweazle/image/fdi.py
@@ -14,7 +14,7 @@ from .image import Image
 from greaseweazle.codec import formats
 
 class FDI(IMG):
-    default_format = 'pc98.hd'
+    default_format = 'pc98.2hd'
     read_only = True
 
     @classmethod

--- a/src/greaseweazle/image/hdm.py
+++ b/src/greaseweazle/image/hdm.py
@@ -8,7 +8,7 @@
 from greaseweazle.image.img import IMG
 
 class HDM(IMG):
-    default_format = 'pc98.hd'
+    default_format = 'pc98.2hd'
 
 # Local variables:
 # python-indent: 4

--- a/src/greaseweazle/image/xdf.py
+++ b/src/greaseweazle/image/xdf.py
@@ -8,7 +8,7 @@
 from greaseweazle.image.img import IMG
 
 class XDF(IMG):
-    default_format = 'pc98.hd'
+    default_format = 'pc98.2hd'
 
 # Local variables:
 # python-indent: 4


### PR DESCRIPTION
This aligns them with NEC and other common Japanese literature.
