### PR TITLE
help text: Group "FORMAT options" into columns

### DIFF
--- a/src/greaseweazle/codec/formats.py
+++ b/src/greaseweazle/codec/formats.py
@@ -208,6 +208,26 @@ def print_formats(cfg=None):
     for l in lines:
         disk_match = re.match(r'\s*disk\s+([\w,.-]+)', l)
         if disk_match:
-            formats.append('  ' + disk_match.group(1))
+            formats.append(disk_match.group(1))
+    formats = list(filter(None, formats))
     formats.sort()
-    return '\n'.join(filter(None, formats))
+    return '\n'.join(format_columns(formats))
+
+
+def format_columns(names, line_width=79, indent='  ', separator=' ', padding=' '):
+    maxlen = max(len(name) for name in names)
+    column_width = len(separator) + maxlen
+    padstr = padding * maxlen
+    def pad(s):
+        return s + padstr[:maxlen - len(s)]
+    num_cols = (line_width - len(indent) + len(separator)) // column_width
+    num_rows = -(len(names) // -num_cols)
+    rows = [[""] * num_cols for i in range(num_rows)]
+    r = c = 0
+    for name in names:
+        rows[r][c] = pad(name)
+        r += 1
+        if r >= num_rows:
+            r = 0
+            c += 1
+    return [indent + separator.join(row).rstrip() for row in rows]


### PR DESCRIPTION
This makes it possible to see the entire output of `gw convert --help` on a 50-line terminal:

```
FORMAT options:
  acorn.adfs.160    atari.90          ibm.1200          pc98.2dd
  acorn.adfs.1600   atarist.360       ibm.1440          pc98.2hd
  acorn.adfs.320    atarist.400       ibm.1680          pc98.2hs
  acorn.adfs.640    atarist.440       ibm.180           sci.prophet
  acorn.adfs.800    atarist.720       ibm.2880          sega.sf7000
  acorn.dfs.ds      atarist.800       ibm.360           tsc.flex.dsdd
  acorn.dfs.ss      atarist.880       ibm.720           tsc.flex.ssdd
  akai.1600         commodore.1581    ibm.800           zx.trdos.640
  akai.800          ensoniq.1600      ibm.dmf
  amiga.amigados    ensoniq.800       olivetti.m20
  amiga.amigados_hd ensoniq.mirage    pc98.2d
```