### PR TITLE
diskdefs: Add Osborne 1 single and double density formats

### DIFF
--- a/src/greaseweazle/data/diskdefs.cfg
+++ b/src/greaseweazle/data/diskdefs.cfg
@@ -433,6 +433,27 @@ disk ibm.2880
     end
 end
 
+# Osborne 1 Single and Double Density formats are just SS, 40 track, FM / MFM, 10 s / 5 s per track
+disk occ1.sd
+   cyls = 40
+   heads = 1
+   tracks * ibm.fm
+	   secs = 10
+	   bps = 256
+	   rate = 125
+   end
+end
+
+disk occ1.dd
+   cyls = 40
+   heads = 1
+   tracks * ibm.mfm
+	   secs = 5
+	   bps = 1024
+	   rate = 250
+   end
+end
+
 # Olivetti M20 360kB DD floppies
 disk olivetti.m20
     cyls = 35


### PR DESCRIPTION
The Osborne 1 has two disk formats, on it's 5.25 single sided, 40-track drives:

"Single Density" (non-upgraded models):
FM, 125kbps, 10 sectors per track, 256 bytes per sector

"Double Density" (an additional upgrade board):
MFM, 250 kbps, 5 sectors per track, 1024 bytes per sector

I can only check occ1.sd, but I can confirm that it works fine.

I can gw read with and without the format, and the .img from gw matches the output of disk-analyse. Writing it back with gw write --format results in a functional copy of the disk.

```
gw read --drive=1 --tracks="c=0-39:h=0" --format occ1.sd help-$(date +%s).img
Reading c=0-39:h=0 revs=2
Format occ1.sd
T0.0: IBM FM (10/10 sectors) from Raw Flux (74512 flux in 400.91ms)
T1.0: IBM FM (10/10 sectors) from Raw Flux (76247 flux in 400.81ms)
T2.0: IBM FM (10/10 sectors) from Raw Flux (73069 flux in 400.67ms)
T3.0: IBM FM (10/10 sectors) from Raw Flux (75505 flux in 400.59ms)
T4.0: IBM FM (10/10 sectors) from Raw Flux (73138 flux in 400.57ms)
T5.0: IBM FM (10/10 sectors) from Raw Flux (73548 flux in 400.43ms)
T6.0: IBM FM (10/10 sectors) from Raw Flux (73196 flux in 400.32ms)
T7.0: IBM FM (10/10 sectors) from Raw Flux (73938 flux in 400.28ms)
T8.0: IBM FM (10/10 sectors) from Raw Flux (72176 flux in 400.20ms)
T9.0: IBM FM (10/10 sectors) from Raw Flux (73541 flux in 400.17ms)
T10.0: IBM FM (10/10 sectors) from Raw Flux (74673 flux in 400.18ms)
T11.0: IBM FM (10/10 sectors) from Raw Flux (74853 flux in 400.09ms)
T12.0: IBM FM (10/10 sectors) from Raw Flux (72706 flux in 400.05ms)
T13.0: IBM FM (10/10 sectors) from Raw Flux (74163 flux in 400.05ms)
T14.0: IBM FM (10/10 sectors) from Raw Flux (76236 flux in 400.06ms)
T15.0: IBM FM (10/10 sectors) from Raw Flux (72548 flux in 400.04ms)
T16.0: IBM FM (10/10 sectors) from Raw Flux (72910 flux in 400.02ms)
T17.0: IBM FM (10/10 sectors) from Raw Flux (74044 flux in 399.98ms)
T18.0: IBM FM (10/10 sectors) from Raw Flux (76769 flux in 400.02ms)
T19.0: IBM FM (10/10 sectors) from Raw Flux (73020 flux in 399.97ms)
T20.0: IBM FM (10/10 sectors) from Raw Flux (74551 flux in 399.95ms)
T21.0: IBM FM (10/10 sectors) from Raw Flux (73817 flux in 400.00ms)
T22.0: IBM FM (10/10 sectors) from Raw Flux (65110 flux in 399.90ms)
T23.0: IBM FM (10/10 sectors) from Raw Flux (69874 flux in 399.86ms)
T24.0: IBM FM (10/10 sectors) from Raw Flux (73919 flux in 399.80ms)
T25.0: IBM FM (10/10 sectors) from Raw Flux (72816 flux in 399.77ms)
T26.0: IBM FM (10/10 sectors) from Raw Flux (71510 flux in 399.75ms)
T27.0: IBM FM (10/10 sectors) from Raw Flux (73111 flux in 399.79ms)
T28.0: IBM FM (10/10 sectors) from Raw Flux (78390 flux in 399.71ms)
T29.0: IBM FM (10/10 sectors) from Raw Flux (74890 flux in 399.70ms)
T30.0: IBM FM (10/10 sectors) from Raw Flux (65247 flux in 399.73ms)
T31.0: IBM FM (10/10 sectors) from Raw Flux (69863 flux in 399.74ms)
T32.0: IBM FM (10/10 sectors) from Raw Flux (73891 flux in 399.70ms)
T33.0: IBM FM (10/10 sectors) from Raw Flux (72912 flux in 399.67ms)
T34.0: IBM FM (10/10 sectors) from Raw Flux (71133 flux in 399.62ms)
T35.0: IBM FM (10/10 sectors) from Raw Flux (81305 flux in 399.70ms)
T36.0: IBM FM (10/10 sectors) from Raw Flux (81298 flux in 399.67ms)
T37.0: IBM FM (10/10 sectors) from Raw Flux (81290 flux in 399.68ms)
T38.0: IBM FM (10/10 sectors) from Raw Flux (81303 flux in 399.74ms)
T39.0: IBM FM (10/10 sectors) from Raw Flux (81325 flux in 399.66ms)
Cyl-> 0         1         2         3         
H. S: 0123456789012345678901234567890123456789
0. 0: ........................................
0. 1: ........................................
0. 2: ........................................
0. 3: ........................................
0. 4: ........................................
0. 5: ........................................
0. 6: ........................................
0. 7: ........................................
0. 8: ........................................
0. 9: ........................................
Found 400 sectors of 400 (100%)

gw read --drive=1 --tracks="c=0-39:h=0"  help-$(date +%s).scp
Reading c=0-39:h=0 revs=3
...

disk-analyse help-1681657390.scp help-1681657390.imd
Side 0:
 T0-39: IBM-FM SD (10 256-byte sectors, 2560 bytes)
 T40-79: Unformatted*
 T80-83: Unformatted
Side 1:
 T0-79: Unformatted*
 T80-83: Unformatted
** WARNING: 120 tracks are damaged or unidentified!

disk-analyse help-1681657390.imd help-1681657390.img
Side 0:
 T0-39: IBM-FM DD (10 256-byte sectors, 2560 bytes)
 T40-83: Unformatted
Side 1:
 T0-83: Unformatted

md5sum help-*.img
da4e906f5f051e6cdfb0a1df263b01e0  help-1681657254.img
da4e906f5f051e6cdfb0a1df263b01e0  help-1681657390.img
```