### PR TITLE
Ccdiskdefs

### DIFF
--- a/src/greaseweazle/data/diskdefs.cfg
+++ b/src/greaseweazle/data/diskdefs.cfg
@@ -264,6 +264,7 @@ end
 disk coco.decb
     cyls = 35
     heads = 1
+	rate = 250
     tracks * ibm.mfm
         secs = 18
         bps = 256
@@ -279,6 +280,7 @@ end
 disk coco.decb.40t
     cyls = 40
     heads = 1
+	rate = 250
     tracks * ibm.mfm
         secs = 18
         bps = 256
@@ -291,9 +293,42 @@ disk coco.decb.40t
     end
 end
 
+disk coco.os9.40ss
+    cyls = 40
+    heads = 1
+	rate = 250
+    tracks * ibm.mfm
+        secs = 18
+        bps = 256
+        id = 1
+        gap2 = 22
+        gap3 = 24
+        gap4a = 32
+        interleave = 3
+        iam = no
+    end
+end
+
 disk coco.os9.40ds
     cyls = 40
     heads = 2
+	rate = 250
+    tracks * ibm.mfm
+        secs = 18
+        bps = 256
+        id = 1
+        gap2 = 22
+        gap3 = 24
+        gap4a = 32
+        interleave = 3
+        iam = no
+    end
+end
+
+disk coco.os9.80ss
+    cyls = 80
+    heads = 1
+	rate = 250
     tracks * ibm.mfm
         secs = 18
         bps = 256
@@ -309,6 +344,7 @@ end
 disk coco.os9.80ds
     cyls = 80
     heads = 2
+	rate = 250
     tracks * ibm.mfm
         secs = 18
         bps = 256

--- a/src/greaseweazle/data/diskdefs.cfg
+++ b/src/greaseweazle/data/diskdefs.cfg
@@ -264,7 +264,6 @@ end
 disk coco.decb
     cyls = 35
     heads = 1
-	rate = 250
     tracks * ibm.mfm
         secs = 18
         bps = 256
@@ -274,13 +273,13 @@ disk coco.decb
         gap4a = 32
         interleave = 5
         iam = no
+		rate = 250
     end
 end
 
 disk coco.decb.40t
     cyls = 40
     heads = 1
-	rate = 250
     tracks * ibm.mfm
         secs = 18
         bps = 256
@@ -290,13 +289,13 @@ disk coco.decb.40t
         gap4a = 32
         interleave = 5
         iam = no
+		rate = 250
     end
 end
 
 disk coco.os9.40ss
     cyls = 40
     heads = 1
-	rate = 250
     tracks * ibm.mfm
         secs = 18
         bps = 256
@@ -306,13 +305,13 @@ disk coco.os9.40ss
         gap4a = 32
         interleave = 3
         iam = no
+		rate = 250
     end
 end
 
 disk coco.os9.40ds
     cyls = 40
     heads = 2
-	rate = 250
     tracks * ibm.mfm
         secs = 18
         bps = 256
@@ -322,13 +321,13 @@ disk coco.os9.40ds
         gap4a = 32
         interleave = 3
         iam = no
+		rate = 250
     end
 end
 
 disk coco.os9.80ss
     cyls = 80
     heads = 1
-	rate = 250
     tracks * ibm.mfm
         secs = 18
         bps = 256
@@ -338,13 +337,13 @@ disk coco.os9.80ss
         gap4a = 32
         interleave = 3
         iam = no
+		rate = 250
     end
 end
 
 disk coco.os9.80ds
     cyls = 80
     heads = 2
-	rate = 250
     tracks * ibm.mfm
         secs = 18
         bps = 256
@@ -354,6 +353,7 @@ disk coco.os9.80ds
         gap4a = 32
         interleave = 3
         iam = no
+		rate = 250
     end
 end
 
@@ -730,7 +730,6 @@ end
 disk mm1.os9.80ds.hd32spt
     cyls = 80
     heads = 2
-	rate = 500
     tracks * ibm.mfm
         secs = 32
         bps = 256
@@ -740,13 +739,13 @@ disk mm1.os9.80ds.hd32spt
         gap4a = 32
         interleave = 3
         iam = no
+		rate = 500
     end
 end
 
 disk mm1.os9.80ds.hd36spt
     cyls = 80
     heads = 2
-	rate = 500
     tracks * ibm.mfm
         secs = 32
         bps = 256
@@ -756,6 +755,7 @@ disk mm1.os9.80ds.hd36spt
         gap4a = 32
         interleave = 3
         iam = no
+		rate = 500
     end
 end
 

--- a/src/greaseweazle/data/diskdefs.cfg
+++ b/src/greaseweazle/data/diskdefs.cfg
@@ -727,6 +727,38 @@ disk msx.1d
     end
 end
 
+disk mm1.os9.80ds.hd32spt
+    cyls = 80
+    heads = 2
+	rate = 500
+    tracks * ibm.mfm
+        secs = 32
+        bps = 256
+        id = 0
+        gap2 = 22
+        gap3 = 24
+        gap4a = 32
+        interleave = 3
+        iam = no
+    end
+end
+
+disk mm1.os9.80ds.hd36spt
+    cyls = 80
+    heads = 2
+	rate = 500
+    tracks * ibm.mfm
+        secs = 32
+        bps = 256
+        id = 0
+        gap2 = 22
+        gap3 = 24
+        gap4a = 32
+        interleave = 3
+        iam = no
+    end
+end
+
 disk msx.1dd
     cyls = 80
     heads = 1


### PR DESCRIPTION
This pull request contains:

Added TRS CoCo Microware OS-9 40 track single sided and 80 track single sided layouts
Updated TRS CoCo disk layouts to have bitrate of 250

Added MM/1 Microware OS-9 80 track double sided high density 32 sector per track and 36 sector per track layouts.