### PR TITLE
Add pc98.n88basic.hd format

### DIFF
--- a/src/greaseweazle/data/diskdefs.cfg
+++ b/src/greaseweazle/data/diskdefs.cfg
@@ -917,6 +917,25 @@ disk pc98.2hd
     end
 end
 
+disk pc98.n88basic.hd
+    cyls = 77
+    heads = 2
+    tracks 0.0 ibm.fm
+        secs = 26
+        bps = 128
+        gap3 = 26
+        rate = 250
+        rpm = 360
+    end
+    tracks * ibm.mfm
+        secs = 26
+        bps = 256
+        gap3 = 26
+        rate = 500
+        rpm = 360
+    end
+end
+
 disk pc98.2hs
     cyls = 81
     heads = 2


### PR DESCRIPTION
This is a slightly unusual format (very similar to rx01) used
by N88-Basic disks for the NEC PC-98.

There is an equivalent DD format that I might add once I am able
to test it.
