### PR TITLE
Add support for writing data-less sectors in IMD.

### DIFF
--- a/src/greaseweazle/codec/ibm/ibm.py
+++ b/src/greaseweazle/codec/ibm/ibm.py
@@ -619,7 +619,7 @@ class IBMTrack(codec.Codec):
             list: List[Any]
             if isinstance(a, IAM):
                 list = self.iams
-            elif isinstance(a, Sector):
+            elif isinstance(a, Sector) or isinstance(a, IDAM):
                 list = self.sectors
             else:
                 continue

--- a/src/greaseweazle/image/imd.py
+++ b/src/greaseweazle/image/imd.py
@@ -163,19 +163,23 @@ class IMD(Image):
             cyl, head, nsec, sec_n = c, h, 0, None
             rmap, cmap, hmap = [], [], []
             for s in t.sectors:
-                if not isinstance(s, ibm.Sector):
+                if isinstance(s, ibm.Sector):
+                    idam = s.idam
+                elif isinstance(s, ibm.IDAM):
+                    idam = s
+                else:
                     continue
                 nsec += 1
-                error.check(s.idam.n == sec_n or sec_n is None,
+                error.check(idam.n == sec_n or sec_n is None,
                             'IMD: Cannot create T%d.%d: Sectors vary in size'
                             % (c,h))
-                sec_n = s.idam.n
-                rmap.append(s.idam.r)
-                cmap.append(s.idam.c)
-                hmap.append(s.idam.h)
-                if s.idam.c != c:
+                sec_n = idam.n
+                rmap.append(idam.r)
+                cmap.append(idam.c)
+                hmap.append(idam.h)
+                if idam.c != c:
                     head |= 0x80
-                if s.idam.h != h:
+                if idam.h != h:
                     head |= 0x40
             if sec_n is None:
                 sec_n = 0
@@ -187,7 +191,10 @@ class IMD(Image):
             if head & 0x40:
                 tdat += bytes(hmap)
             for s in t.sectors:
-                if not isinstance(s, ibm.Sector):
+                if isinstance(s, ibm.IDAM):
+                    tdat += bytes([0])
+                    continue
+                elif not isinstance(s, ibm.Sector):
                     continue
                 rec = 0
                 if s.dam.data.count(s.dam.data[0]) == secsz:


### PR DESCRIPTION
This adds sector record 0 type support to the IMD writer.

It currently adds IDAM areas into the sector list. Most writers
seem to be able to skip these appropriately, however I'm not
sure mixing data types in the sector list is the best approach.
Other approaches included a None or special DAM, or a dedicated
list of IDAMs like the IAM list.

The reader can read these back but currently does not encode a
flux stream without a DAM.

(it does seem this feature is relatively poorly supported in
IMD readers as well)
