### PR TITLE
Create any missing directories in output path

### DIFF
--- a/src/greaseweazle/image/image.py
+++ b/src/greaseweazle/image/image.py
@@ -23,6 +23,7 @@ class Image:
     ## Context manager for image objects created using .to_file()
 
     def __enter__(self):
+        os.makedirs(os.path.dirname(self.filename), exist_ok=True)
         self.file = open(self.filename, ('wb','xb')[self.noclobber])
         return self
 


### PR DESCRIPTION
Small quality of life improvement : when opening an image for writing, create any missing directories contained in the output path.

This is mainly useful when writing Kryoflux RAW files, which you might typically want to keep together in a subdirectory without having to create it manually beforehand (e.g.  `gw read greatgame/00.0.raw`)