### PR TITLE
Add support for BBC DDFS disks/drives

### DIFF
--- a/src/greaseweazle/data/diskdefs.cfg
+++ b/src/greaseweazle/data/diskdefs.cfg
@@ -131,6 +131,20 @@ disk acorn.dfs.ss
     end
 end
 
+disk acorn.ddfs.ss
+    cyls = 80
+    heads = 1
+    tracks * ibm.fm
+        secs = 10
+        bps = 256
+        iam = no
+        gap3 = 21
+        id = 0
+        cskew = 3
+        rate = 125
+    end
+end
+
 disk acorn.dfs.ds
     cyls = 40
     heads = 2


### PR DESCRIPTION
BBC Micros had the possibility for 80T disks that were FM formatted. The drives typically have a 40/80T switch for this. Typically this would be called DDFS by most manufacturers, although Acorn's 1770 DFS falls into this category.

This commit adds a profile to read disks when hooked up to a BBC Micro disk drive in 80T mode.

Note that there is no DS option as interleaved DS was not really a thing on BBC Micros, sides were given separate drive numbers.