### PR TITLE
Revert "Add support for BBC DDFS disks/drives"

### DIFF
--- a/src/greaseweazle/data/diskdefs.cfg
+++ b/src/greaseweazle/data/diskdefs.cfg
@@ -131,20 +131,6 @@ disk acorn.dfs.ss
     end
 end
 
-disk acorn.ddfs.ss
-    cyls = 80
-    heads = 1
-    tracks * ibm.fm
-        secs = 10
-        bps = 256
-        iam = no
-        gap3 = 21
-        id = 0
-        cskew = 3
-        rate = 125
-    end
-end
-
 disk acorn.dfs.ds
     cyls = 40
     heads = 2


### PR DESCRIPTION
Reverts keirf/greaseweazle#427

DDFS was a double density DFS, deployed by Watford (and others) with their
1770 disk interface - it's an MFM format, and could be 40 or 80 track,
single or double sided (not interleaved). 80 track FM was simply 80 track
DFS format (again, single or double sided not interleaved). Check here for
more detail: https://stardot.org.uk/forums/viewtopic.php?p=390348#p390348
