### PR TITLE
score_port: Accept "gw-compat" products

### DIFF
--- a/src/greaseweazle/tools/util.py
+++ b/src/greaseweazle/tools/util.py
@@ -344,6 +344,8 @@ def score_port(x, old_port=None):
     elif x.vid == 0x1209 and x.pid == 0x0001:
         # Our old shared Test PID. It's not guaranteed to be us.
         score = 10
+    if "gw-compat" in x.product.lower():
+        score = 19
     if score > 0 and valid_ser_id(x.serial_number):
         # A valid serial id is a good sign unless this is a reopen, and
         # the serials don't match!


### PR DESCRIPTION
If the USB device's product string contains "gw-compat" (case insensitive), it will be treated as a device greaseweazle can use, albeit at a lower priority than a genuine Greaseweazle.

Together with a 1-liner change in Adafruit_Floppy's compatible firmware, this allows `gw` commands to work with that firmware without specifying a --device to every command.

If you'd prefer to accomplish this in a different way, I'm open to your suggestions. For instance, I think Adafruit could allocate a unique VID:PID for an Adafruit product running this sketch. This might also be easier better for compatibility with @davidgiven's fluxengine, which doesn't currently look at product strings, just VID:PID pairs, when deciding device compatibility. (however, it might have consequences within the Arduino programming environment which likes to detect device type from the VID:PID and would possibly fail to detect a device once it was programmed with that FW)