### PR TITLE
diskdefs: Add support for Epson QX-10 disk formats

### DIFF
--- a/src/greaseweazle/data/diskdefs.cfg
+++ b/src/greaseweazle/data/diskdefs.cfg
@@ -585,6 +585,100 @@ disk ensoniq.mirage
     end
 end
 
+# This is a slightly odd format with sevral unformatted tracks.
+# I've seen this used with logo professor and a few other pieces
+# of software.
+disk epson.qx10.logo
+    cyls = 40
+    heads = 2
+    tracks 0-1,4 ibm.mfm
+        secs = 16
+        bps = 256
+        rate = 250
+    end
+    tracks 5,6 ibm.mfm
+        id = 2
+        secs = 10
+        bps = 512
+        rate = 250
+    end
+    tracks 2,8-39 ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+    end
+end
+
+# This is a format used with several self-booting games.
+disk epson.qx10.booter
+    cyls = 15
+    heads = 1
+    tracks 0 ibm.mfm
+        secs = 16
+        bps = 256
+        rate = 250
+    end
+    tracks * ibm.mfm
+        secs = 17
+        bps = 256
+        rate = 250
+    end
+end
+
+# This is the QX+ format used with CPM Plus on the QX-10. Does not support system disks.
+disk epson.qx10.400
+    cyls = 40
+    heads = 2
+    tracks * ibm.mfm
+        secs = 5
+        bps = 1024
+        rate = 250
+    end
+end
+
+# This is a less common format with only track 0 using 16 256 byte sectors.
+disk epson.qx10.399
+    cyls = 40
+    heads = 2
+    tracks 0.0 ibm.mfm
+        secs = 16
+        bps = 256
+        rate = 250
+    end
+    tracks * ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+    end
+end
+
+# Newer more common format capable of 396k of storage.
+disk epson.qx10.396
+    cyls = 40
+    heads = 2
+    tracks 0-1 ibm.mfm
+        secs = 16
+        bps = 256
+        rate = 250
+    end
+    tracks * ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+    end
+end
+
+# Original Epson QX-10 format providing 320k of storage.
+disk epson.qx10.320
+    cyls = 40
+    heads = 2
+    tracks * ibm.mfm
+        secs = 16
+        bps = 256
+        rate = 250
+    end
+end
+
 # General Music (GEM) S2 and S3
 disk gem.1600
     cyls = 80


### PR DESCRIPTION
This adds diskdefs  for various Epson QX-10 formats I have seen used while imaging disks for that system.