### PR TITLE
Add thomson format definitions

### DIFF
--- a/src/greaseweazle/data/diskdefs.cfg
+++ b/src/greaseweazle/data/diskdefs.cfg
@@ -1388,6 +1388,83 @@ disk tsc.flex.ssdd
   end
 end
 
+
+# Disk formats for Thomson MO5, MO6, TO7, TO7/70, TO8, TO8D, TO9, TO9+ computers:
+
+# 5"1/4 simple density, 1 side = 80 kB
+# @fplanque: Tested Read only
+disk thomson.1s80
+    cyls = 40
+    heads = 1
+    tracks * ibm.fm
+        secs = 16
+        bps = 128
+        rate = 250
+        interleave = 7
+    rpm = 300
+    end
+end
+
+# Note: Thomson never released 5"1/4 simple density doubled sided drives
+
+# 5"1/4 double density, 1 side = 160 kB
+disk thomson.1s160
+    cyls = 40
+    heads = 1
+    tracks * ibm.fm
+        secs = 16
+        bps = 256
+        rate = 250
+        interleave = 7
+    rpm = 300
+    end
+end
+
+# 5"1/4 double density, 2 sides = 2x160 kB
+# Note: on Thomson each side is addressed independently, so it's really 2x160 and not 320.
+# TODO: requires support for sidebased .fd format to thoroughly test read/write
+disk thomson.2s160
+    cyls = 40
+    heads = 2
+    tracks * ibm.fm
+        secs = 16
+        bps = 256
+        rate = 250
+        interleave = 7
+    rpm = 300
+    end
+end
+
+# 3"1/2 double density, 1 side = 320 kB
+# @fplanque: Tested Read and Write
+disk thomson.1s320
+    cyls = 80
+    heads = 1
+    tracks * ibm.mfm
+        secs = 16
+        bps = 256
+        rate = 250
+        interleave = 7
+    rpm = 300
+    end
+end
+
+# 3"1/2 double density, 2 sides = 2x320 kB
+# Note: on Thomson each side is addressed independently, so it's really 2x320 and not 640.
+# TODO: requires support for sidebased .fd format to thoroughly test read/write
+disk thomson.2s320
+    cyls = 80
+    heads = 2
+    tracks * ibm.mfm
+        secs = 16
+        bps = 256
+        rate = 250
+        interleave = 7
+    rpm = 300
+    end
+end
+
+
 disk zx.trdos.640
     cyls = 80
     heads = 2


### PR DESCRIPTION
I added definitions for all the floppy disk formats that were released  by Thomson along the history of the MO5, MO6, TO7, TO7/70, TO8, TO8D, TO9 & TO9+ computers.

Ideally, this would be complemented by support for .fd files (same as .img but with all tracks and sectors of side 0 before all tracks/sectors of side 1).