### PR TITLE
Default for FD format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 /dist/
 /src/greaseweazle/__init__.py
 
+/.DS_Store

--- a/src/greaseweazle/image/fd.py
+++ b/src/greaseweazle/image/fd.py
@@ -4,12 +4,17 @@
 #
 # This is free and unencumbered software released into the public domain.
 # See the file COPYING for more details, or visit <http://unlicense.org>.
+#
+# .fd is a widely used format in the Thomson MO/TO community.
+# .fd is directly supported by emulators such as DCMOTO.
+# The main difference between IMG and FD is that FD completely separates both sides of a disk,
+# i-e, all tacks/sectors of side 0 are stored before all tracks/sectors of side 1.
 
 from greaseweazle.image.img import IMG
 
 class FD(IMG):
-    default_format = 'thomson.1s80'
-    sequential = True
+    default_format = 'thomson.1s320'    # Most commonly used format
+    sequential = True                   # while side 0 before whole side 1
 
 # Local variables:
 # python-indent: 4


### PR DESCRIPTION
I changed to default to `thomson.1s320` which I believe is the most commonly used format in the community today.

Also added a few comments for reference.

Also took the liberty to `.ignore` the mac `.DS_Store` files ;)