### PR TITLE
Use raw strings for regexes; fixes SyntaxWarning: invalid escape sequence

### DIFF
--- a/scripts/misc/artifact.py
+++ b/scripts/misc/artifact.py
@@ -28,15 +28,15 @@ else:
     download = False
     url = sys.argv[1]
 
-url = re.sub('github.com', 'nightly.link', url)
-url = re.sub('suites/\d+', 'actions', url)
+url = re.sub(r'github.com', 'nightly.link', url)
+url = re.sub(r'suites/\d+', 'actions', url)
 url += '.zip'
 print(url)
 
 if download:
     res = requests.get(url)
     content_disposition = res.headers['Content-Disposition']
-    zipname = re.search('filename=([^ ]+.zip);', content_disposition).group(1)
+    zipname = re.search(r'filename=([^ ]+.zip);', content_disposition).group(1)
     print('Downloading to: ' + zipname)
     with open(zipname, 'wb') as f:
         f.write(res.content)

--- a/src/greaseweazle/codec/codec.py
+++ b/src/greaseweazle/codec/codec.py
@@ -214,7 +214,7 @@ def get_diskdef(
                     active = False
                     continue
                 tracks_match = re.match(r'tracks\s+([0-9,.*-]+)'
-                                        '\s+([\w,.-]+)', t)
+                                        r'\s+([\w,.-]+)', t)
                 if tracks_match:
                     parse_mode = ParseMode.Track
                     if not active:
@@ -233,7 +233,7 @@ def get_diskdef(
                                         disk.track_map[c,hd] = track
                         else:
                             t_match = re.match(r'(\d+)(?:-(\d+))?'
-                                               '(?:\.([01]))?', x)
+                                               r'(?:\.([01]))?', x)
                             error.check(t_match is not None,
                                         'bad track specifier')
                             assert t_match is not None # mypy
@@ -261,7 +261,7 @@ def get_diskdef(
                 assert disk is not None # mypy
 
                 keyval_match = re.match(r'([a-zA-Z0-9:,._-]+)\s*='
-                                        '\s*([a-zA-Z0-9:,._-]+)', t)
+                                        r'\s*([a-zA-Z0-9:,._-]+)', t)
                 error.check(keyval_match is not None, 'syntax error')
                 assert keyval_match is not None # mypy
                 disk.add_param(keyval_match.group(1),
@@ -280,7 +280,7 @@ def get_diskdef(
                 assert track is not None # mypy
 
                 keyval_match = re.match(r'([a-zA-Z0-9:,._-]+)\s*='
-                                        '\s*([a-zA-Z0-9:,._*-]+)', t)
+                                        r'\s*([a-zA-Z0-9:,._*-]+)', t)
                 error.check(keyval_match is not None, 'syntax error')
                 assert keyval_match is not None # mypy
                 track.add_param(keyval_match.group(1),

--- a/src/greaseweazle/tools/util.py
+++ b/src/greaseweazle/tools/util.py
@@ -100,19 +100,19 @@ PLLSPEC: Colon-separated list of:
 # Returns time period in seconds (float)
 # Accepts rpm, ms, us, ns, scp. Naked value is assumed rpm.
 def period(arg):
-    m = re.match('(\d*\.\d+|\d+)rpm', arg)
+    m = re.match(r'(\d*\.\d+|\d+)rpm', arg)
     if m is not None:
         return 60 / float(m.group(1))
-    m = re.match('(\d*\.\d+|\d+)ms', arg)
+    m = re.match(r'(\d*\.\d+|\d+)ms', arg)
     if m is not None:
         return float(m.group(1)) / 1e3
-    m = re.match('(\d*\.\d+|\d+)us', arg)
+    m = re.match(r'(\d*\.\d+|\d+)us', arg)
     if m is not None:
         return float(m.group(1)) / 1e6
-    m = re.match('(\d*\.\d+|\d+)ns', arg)
+    m = re.match(r'(\d*\.\d+|\d+)ns', arg)
     if m is not None:
         return float(m.group(1)) / 1e9
-    m = re.match('(\d*\.\d+|\d+)scp', arg)
+    m = re.match(r'(\d*\.\d+|\d+)scp', arg)
     if m is not None:
         return float(m.group(1)) / 40e6 # SCP @ 40MHz
     return 60 / float(arg)
@@ -190,7 +190,7 @@ class TrackSet:
             if k == 'c':
                 cyls = set()
                 for crange in v.split(','):
-                    m = re.match('(\d+)(-(\d+)(/(\d+))?)?$', crange)
+                    m = re.match(r'(\d+)(-(\d+)(/(\d+))?)?$', crange)
                     if m is None: raise ValueError()
                     if m.group(3) is None:
                         s,e,step = int(m.group(1)), int(m.group(1)), 1
@@ -204,7 +204,7 @@ class TrackSet:
             elif k == 'h':
                 heads = [False]*2
                 for hrange in v.split(','):
-                    m = re.match('([01])(-([01]))?$', hrange)
+                    m = re.match(r'([01])(-([01]))?$', hrange)
                     if m is None: raise ValueError()
                     if m.group(3) is None:
                         s,e = int(m.group(1)), int(m.group(1))
@@ -215,13 +215,13 @@ class TrackSet:
                 self.heads = []
                 for h in range(len(heads)):
                     if heads[h]: self.heads.append(h)
-            elif re.match('h[01].off$', k):
-                h = int(re.match('h([01]).off$', k).group(1))
-                m = re.match('([+-]\d+)$', v)
+            elif re.match(r'h[01].off$', k):
+                h = int(re.match(r'h([01]).off$', k).group(1))
+                m = re.match(r'([+-]\d+)$', v)
                 if m is None: raise ValueError()
                 self.h_off[h] = int(m.group(1))
             elif k == 'step':
-                m = re.match('1/(\d+)$', v)
+                m = re.match(r'1/(\d+)$', v)
                 self.step = -int(m.group(1)) if m is not None else int(v)
             else:
                 raise ValueError()


### PR DESCRIPTION
When running `gw --help` for the first time under Python 3.12, I get a bunch of warnings:

```

.../src/greaseweazle/tools/util.py:103: SyntaxWarning: invalid escape sequence '\d'
  m = re.match('(\d*\.\d+|\d+)rpm', arg)
.../src/greaseweazle/tools/util.py:106: SyntaxWarning: invalid escape sequence '\d'
  m = re.match('(\d*\.\d+|\d+)ms', arg)
.../src/greaseweazle/tools/util.py:109: SyntaxWarning: invalid escape sequence '\d'
  m = re.match('(\d*\.\d+|\d+)us', arg)
.../src/greaseweazle/tools/util.py:112: SyntaxWarning: invalid escape sequence '\d'
  m = re.match('(\d*\.\d+|\d+)ns', arg)
.../src/greaseweazle/tools/util.py:115: SyntaxWarning: invalid escape sequence '\d'
  m = re.match('(\d*\.\d+|\d+)scp', arg)
.../src/greaseweazle/tools/util.py:193: SyntaxWarning: invalid escape sequence '\d'
  m = re.match('(\d+)(-(\d+)(/(\d+))?)?$', crange)
.../src/greaseweazle/tools/util.py:220: SyntaxWarning: invalid escape sequence '\d'
  m = re.match('([+-]\d+)$', v)
.../src/greaseweazle/tools/util.py:224: SyntaxWarning: invalid escape sequence '\d'
  m = re.match('1/(\d+)$', v)
  info        Display information about the Greaseweazle setup.
.../src/greaseweazle/codec/codec.py:217: SyntaxWarning: invalid escape sequence '\s'
  '\s+([\w,.-]+)', t)
.../src/greaseweazle/codec/codec.py:236: SyntaxWarning: invalid escape sequence '\.'
  '(?:\.([01]))?', x)
.../src/greaseweazle/codec/codec.py:264: SyntaxWarning: invalid escape sequence '\s'
  '\s*([a-zA-Z0-9:,._-]+)', t)
.../src/greaseweazle/codec/codec.py:283: SyntaxWarning: invalid escape sequence '\s'
  '\s*([a-zA-Z0-9:,._*-]+)', t)
```

This doesn't happen when loading the cached .pyc files, so to reproduce the original problem, remove the `__pycache__` directories before running `gw`.

This pull request fixes these errors by using raw strings (r'foo\d' instead of 'foo\d').