### PR TITLE
Print raw flux summary even if no format conversion was applied for out of range tracks

### DIFF
--- a/src/greaseweazle/tools/read.py
+++ b/src/greaseweazle/tools/read.py
@@ -70,7 +70,8 @@ def read_with_retry(usb: USB.Unit, args, t) -> Tuple[Flux, Optional[HasFlux]]:
     dat = args.fmt_cls.decode_flux(cyl, head, flux)
     if dat is None:
         print("%s: WARNING: Out of range for format '%s': No format "
-              "conversion applied" % (tspec, args.format))
+              "conversion applied: %s" % (tspec, args.format,
+                flux.summary_string()))
         return flux, None
     for pll in plls[1:]:
         if dat.nr_missing() == 0:


### PR DESCRIPTION
Really small QoL improvement: when reading raw flux with a format applied, tracks outside the range of that format would not display the raw flux summary.

This is still useful information because we're still getting raw flux even if it doesn't match the format, and we're probably intentionally reading these extra tracks because they might contain extra data (e.g. for copy protection).

![image](https://github.com/user-attachments/assets/93f1422f-3650-4a58-8171-d7086afe411c)
