### PR TITLE
diskdefs: Add support for more ZX Spectrum disk formats

### DIFF
--- a/src/greaseweazle/data/diskdefs_zx.cfg
+++ b/src/greaseweazle/data/diskdefs_zx.cfg
@@ -1,6 +1,7 @@
 # prefix: zx.
 
-disk trdos.640
+# Betadisk TR-DOS
+disk trdos.dsdd
     cyls = 80
     heads = 2
     tracks * ibm.mfm
@@ -11,11 +12,234 @@ disk trdos.640
 end
 
 # Quorum (ZX Spectrum clone) running CP/M-80
-disk quorum.800
+disk quorum.dsdd
     cyls = 80
     heads = 2
     tracks * ibm.mfm
         secs = 5
         bps = 1024
+    end
+end
+
+# Didaktik D80 
+disk d80.dsdd
+    cyls = 80
+    heads = 2
+    tracks * ibm.mfm
+        secs = 9
+        bps = 512
+    end
+end
+
+#Timex FDD 3/3000
+disk fdd3000.sssd
+ cyls = 40
+    heads = 1
+    tracks 0-39 ibm.mfm
+        secs = 16
+        bps = 256
+        id = 0
+        rate = 250
+	h = 0
+    end
+end
+
+disk fdd3000.dsdd
+ cyls = 80
+    heads = 2
+    tracks 0-79 ibm.mfm
+        secs = 16
+        bps = 256
+        id = 0
+        rate = 250
+	h = 1
+    end
+    tracks 0-79 ibm.mfm
+        secs = 16
+        bps = 256
+        id = 0
+        rate = 250
+	h = 0
+    end
+end
+
+# Kempston Disk Interface
+disk kempston.sssd
+ cyls = 40
+    heads = 1
+    tracks * ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+	id=0
+    end
+end
+
+disk kempston.dsdd
+ cyls = 80
+    heads = 2
+    tracks * ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+	id=0
+    end
+end
+
+# MGT +D
+disk plusd.dsdd
+    cyls = 80
+    heads = 2
+    tracks * ibm.mfm
+        secs = 10
+        bps = 512
+    end
+end
+
+#ZX Spectrum Opus Discovery
+disk opus.sssd
+ cyls = 40
+    heads = 1
+    tracks * ibm.mfm
+        secs = 18
+        bps = 256
+        id = 0
+        rate = 250
+	cskew = 13
+	interleave=13
+	iam = no
+    end
+end
+
+disk opus.dsdd
+ cyls = 80
+    heads = 2
+    tracks * ibm.mfm
+        secs = 18
+        bps = 256
+        id = 0
+        rate = 250
+	cskew = 13
+	interleave=13
+	iam = no
+    end
+end
+
+# ZX Spectrum +3DOS
+disk 3dos.sssd
+ cyls = 40
+    heads = 1
+    tracks * ibm.mfm
+        secs = 9
+        bps = 512
+        rate = 250
+    end
+end
+
+disk 3dos.dsdd
+ cyls = 80
+    heads = 2
+    tracks * ibm.mfm
+        secs = 9
+        bps = 512
+        rate = 250
+    end
+end
+
+# Rocky Gush
+disk rocky.sssd
+ cyls = 40
+    heads = 1
+    tracks 0-79 ibm.mfm
+        secs = 5
+        bps = 1024
+        id = 0
+        rate = 250
+	h = 0
+    end
+end
+
+disk rocky.dsdd
+ cyls = 80
+    heads = 2
+    tracks 0-79 ibm.mfm
+        secs = 5
+        bps = 1024
+        id = 0
+        rate = 250
+	h = 1
+    end
+	tracks 0-79 ibm.mfm
+        secs = 5
+        bps = 1024
+        id = 0
+        rate = 250
+	h = 0
+    end
+end
+
+# Turbodrive
+disk turbodrive.dssd
+ cyls = 40
+    heads = 2
+    tracks 0-39 ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+	interleave = 5
+	cskew = 5
+	h = 1
+    end
+	tracks 0-39 ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+	interleave = 5
+	cskew = 5
+	h = 0
+    end
+end
+
+disk turbodrive.dsdd
+ cyls = 80
+    heads = 2
+    tracks 0-79 ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+	interleave = 5
+	cskew = 5
+	h = 1
+    end
+	tracks 0-79 ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+	interleave = 5
+	cskew = 5
+	h = 0
+    end
+end
+
+# Watford SPDOS
+disk watford.sssd
+ cyls = 40
+    heads = 1
+    tracks * ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+	id=0
+    end
+end
+
+disk watford.dsdd
+ cyls = 80
+    heads = 2
+    tracks * ibm.mfm
+        secs = 10
+        bps = 512
+        rate = 250
+	id=0
     end
 end


### PR DESCRIPTION
Adds new definitions for ZX Spectrum disk interfaces.
Fixes to TR-DOS and Quorum to standardize naming.