### PR TITLE
Update diskdefs_zx.cfg to standardize ZX Spectrum disk format definitions.

### DIFF
--- a/src/greaseweazle/data/diskdefs_zx.cfg
+++ b/src/greaseweazle/data/diskdefs_zx.cfg
@@ -1,7 +1,7 @@
 # prefix: zx.
 
 # Betadisk TR-DOS
-disk trdos.dsdd
+disk trdos.ds80
     cyls = 80
     heads = 2
     tracks * ibm.mfm
@@ -12,7 +12,7 @@ disk trdos.dsdd
 end
 
 # Quorum (ZX Spectrum clone) running CP/M-80
-disk quorum.dsdd
+disk quorum.ds80
     cyls = 80
     heads = 2
     tracks * ibm.mfm
@@ -22,7 +22,7 @@ disk quorum.dsdd
 end
 
 # Didaktik D80 
-disk d80.dsdd
+disk d80.ds80
     cyls = 80
     heads = 2
     tracks * ibm.mfm
@@ -32,7 +32,7 @@ disk d80.dsdd
 end
 
 #Timex FDD 3/3000
-disk fdd3000.sssd
+disk fdd3000.ss40
  cyls = 40
     heads = 1
     tracks 0-39 ibm.mfm
@@ -44,7 +44,7 @@ disk fdd3000.sssd
     end
 end
 
-disk fdd3000.dsdd
+disk fdd3000.ds80
  cyls = 80
     heads = 2
     tracks 0-79 ibm.mfm
@@ -64,7 +64,7 @@ disk fdd3000.dsdd
 end
 
 # Kempston Disk Interface
-disk kempston.sssd
+disk kempston.ss40
  cyls = 40
     heads = 1
     tracks * ibm.mfm
@@ -75,7 +75,7 @@ disk kempston.sssd
     end
 end
 
-disk kempston.dsdd
+disk kempston.ds80
  cyls = 80
     heads = 2
     tracks * ibm.mfm
@@ -87,7 +87,7 @@ disk kempston.dsdd
 end
 
 # MGT +D
-disk plusd.dsdd
+disk plusd.ds80
     cyls = 80
     heads = 2
     tracks * ibm.mfm
@@ -97,7 +97,7 @@ disk plusd.dsdd
 end
 
 #ZX Spectrum Opus Discovery
-disk opus.sssd
+disk opus.ss40
  cyls = 40
     heads = 1
     tracks * ibm.mfm
@@ -111,7 +111,7 @@ disk opus.sssd
     end
 end
 
-disk opus.dsdd
+disk opus.ds80
  cyls = 80
     heads = 2
     tracks * ibm.mfm
@@ -126,7 +126,7 @@ disk opus.dsdd
 end
 
 # ZX Spectrum +3DOS
-disk 3dos.sssd
+disk 3dos.ss40
  cyls = 40
     heads = 1
     tracks * ibm.mfm
@@ -136,7 +136,7 @@ disk 3dos.sssd
     end
 end
 
-disk 3dos.dsdd
+disk 3dos.ds80
  cyls = 80
     heads = 2
     tracks * ibm.mfm
@@ -147,7 +147,7 @@ disk 3dos.dsdd
 end
 
 # Rocky Gush
-disk rocky.sssd
+disk rocky.ss40
  cyls = 40
     heads = 1
     tracks 0-79 ibm.mfm
@@ -159,7 +159,7 @@ disk rocky.sssd
     end
 end
 
-disk rocky.dsdd
+disk rocky.ds80
  cyls = 80
     heads = 2
     tracks 0-79 ibm.mfm
@@ -179,7 +179,7 @@ disk rocky.dsdd
 end
 
 # Turbodrive
-disk turbodrive.dssd
+disk turbodrive.ds40
  cyls = 40
     heads = 2
     tracks 0-39 ibm.mfm
@@ -200,7 +200,7 @@ disk turbodrive.dssd
     end
 end
 
-disk turbodrive.dsdd
+disk turbodrive.ds80
  cyls = 80
     heads = 2
     tracks 0-79 ibm.mfm
@@ -222,7 +222,7 @@ disk turbodrive.dsdd
 end
 
 # Watford SPDOS
-disk watford.sssd
+disk watford.ss40
  cyls = 40
     heads = 1
     tracks * ibm.mfm
@@ -233,7 +233,7 @@ disk watford.sssd
     end
 end
 
-disk watford.dsdd
+disk watford.ds80
  cyls = 80
     heads = 2
     tracks * ibm.mfm


### PR DESCRIPTION
Standardized the naming convention for disk formats across various ZX Spectrum and compatible systems:
Replaced .dsdd suffix with .ds80 for all double-sided, 80-cylinder disk configurations to improve clarity and consistency.
Replaced .sssd suffix with .ss40 for all single-sided, 40-cylinder disk configurations to align with uniform terminology.
This update ensures a more intuitive and standardized configuration file for better readability and maintainability across supported platforms.