### PR TITLE
Fix for issue #549

### DIFF
--- a/src/greaseweazle/tools/list_ports_windows.py
+++ b/src/greaseweazle/tools/list_ports_windows.py
@@ -1317,6 +1317,9 @@ def iterate_comports(cache_usb_info=True):
             continue
         yielded_devices.append(port_device)
 
+        # Skip ports with empty names.
+        if port_device.port_name is None:
+            continue
         # Skip parallel ports.
         if port_device.port_name.startswith('LPT'):
             continue


### PR DESCRIPTION
This pull request fixes an issue with evaluation of usb ports. When a port name is empty, gw.exe crashes when accessing 
 properties of a 'NoneType' object.