### PR TITLE
Add PRECOMP documentation for gw write

### DIFF
--- a/src/greaseweazle/tools/util.py
+++ b/src/greaseweazle/tools/util.py
@@ -97,6 +97,13 @@ PLLSPEC: Colon-separated list of:
   Defaults: period=5:phase=60 (no lowpass filter)
 """
 
+precompspec_desc = """\
+PRECOMP: Any of the following elements:
+  type=<t>            :: Precomp type (mfm, fm, gcr): Default mfm
+  <c>=<p>             :: Precompensate all cylinders >= c by p nanoseconds
+  e.g. '40=125' to apply 125ns MFM precompensation to cylinders 40 and higher
+"""
+
 # Returns time period in seconds (float)
 # Accepts rpm, ms, us, ns, scp. Naked value is assumed rpm.
 def period(arg):

--- a/src/greaseweazle/tools/write.py
+++ b/src/greaseweazle/tools/write.py
@@ -211,6 +211,7 @@ def main(argv) -> None:
 
     epilog = (util.drive_desc + "\n"
               + util.speed_desc + "\n" + util.tspec_desc
+              + "\n" + util.precompspec_desc
               + "\nFORMAT options:\n" + codec.print_formats()
               + "\n\nSupported file suffixes:\n"
               + util.columnify(util.image_types))


### PR DESCRIPTION
When you run `gw write --help`, the help contains `--precomp=PRECOMP` but `PRECOMP` is not described later. Since value of this parameter is difficult to guess, this pull request adds the missing PRECOMP description into gw write. The precompensation information was taken from https://github.com/keirf/greaseweazle/wiki/Write-Precompensation.