### PR TITLE
Added definition for DEC RX50

### DIFF
--- a/src/greaseweazle/data/diskdefs_dec.cfg
+++ b/src/greaseweazle/data/diskdefs_dec.cfg
@@ -23,3 +23,15 @@ disk rx02
         rpm = 360
     end
 end
+
+# one side, 80 tracks, 10 sectors per track, MFM encoding
+disk rx50
+    cyls = 80
+    heads = 1
+    tracks * ibm.mfm
+        secs = 10
+        bps = 512
+        rpm = 300
+    end
+end
+


### PR DESCRIPTION
I've read flux of a dozen 5.25" floppies from a Dec Rainbow system on a 80 tracks drive. According to Wikipedia, the Rainbow used RX50 format, that has been described, added to gw and tested. SCP samples available on request.