### PR TITLE
Add proper support for Sharp 2HS images

### DIFF
--- a/src/greaseweazle/codec/ibm/ibm.py
+++ b/src/greaseweazle/codec/ibm/ibm.py
@@ -785,8 +785,9 @@ class IBMTrack_Fixed(IBMTrack):
         for sec in sec_map(nsec, config.interleave,
                            config.cskew, config.hskew, cyl, head):
             pos += t.gap_presync
+            r = id0+sec if not config.ids else config.ids[sec]
             idam = IDAM(pos*16, (pos+synclen+4+2)*16, 0xffff,
-                        c = cyl, h = h, r = id0+sec, n = sec_n(sec))
+                        c = cyl, h = h, r = r, n = sec_n(sec))
             pos += synclen + 4 + 2 + gap2 + t.gap_presync
             size = 128 << idam.n
             datsz = size*2 if mark_dam == Mark.DAM_DEC_MMFM else size
@@ -806,6 +807,7 @@ class IBMTrack_FixedDef(codec.TrackDef):
         self.secs = 0
         self.sz: List[int] = []
         self.id = 1
+        self.ids: List[int] = []
         self.h: Optional[int] = None
         self.format_name = format_name
         self.interleave = 1
@@ -848,6 +850,11 @@ class IBMTrack_FixedDef(codec.TrackDef):
             n = int(val, base=0)
             error.check(0 <= n <= 255, '%s out of range' % key)
             setattr(self, key, n)
+        elif key == 'ids':
+            for x in val.split(','):
+                n = int(x, base=0)
+                error.check(0 <= n <= 255, 'id out of range')
+                self.ids.append(n)
         elif key in ['gap1', 'gap2', 'gap3', 'gap4a', 'gapbyte', 'h']:
             if val == 'auto':
                 n = None
@@ -876,6 +883,10 @@ class IBMTrack_FixedDef(codec.TrackDef):
                     'gap1 specified but no iam')
         error.check(self.secs == 0 or len(self.sz) != 0,
                     'sector size not specified')
+        error.check(self.id == 1 or len(self.ids) == 0,
+                    'base id and id list both present')
+        error.check(len(self.ids) == 0 or len(self.ids) == self.secs,
+                    'sector id list length must match number of sectors')
         error.check((self.img_bps is None
                      or self.img_bps >= max(self.sz, default=0)),
                     'img_bps cannot be smaller than sector data size')

--- a/src/greaseweazle/data/diskdefs_sharp.cfg
+++ b/src/greaseweazle/data/diskdefs_sharp.cfg
@@ -11,3 +11,24 @@ disk 2d
         rpm = 300
     end
 end
+
+disk 2hs
+    cyls = 81
+    heads = 2
+    tracks 0.0 ibm.mfm
+        secs = 9
+        bps = 1024
+        gap3 = 116
+        rate = 500
+        rpm = 300
+        ids = 1,11,12,13,14,15,16,17,18
+    end
+    tracks * ibm.mfm
+        secs = 9
+        bps = 1024
+        gap3 = 116
+        rate = 500
+        rpm = 300
+        id = 10
+    end
+end

--- a/src/greaseweazle/image/dim.py
+++ b/src/greaseweazle/image/dim.py
@@ -22,15 +22,21 @@ class DIM(IMG_AutoFormat):
         with open(name, "rb") as f:
             header = f.read(256)
 
-        error.check(header[0xAB:0xB8] == b"DIFC HEADER  ",
-                    "DIM: Not a DIM file.")
-        media_byte, = struct.unpack('B255x', header)
-        if media_byte == 0:
-            format_str = 'pc98.2hd'
-        elif media_byte == 1:
-            format_str = 'pc98.2hs'
-        else:
-            raise error.Fatal("DIM: Unsupported format.")
+            error.check(header[0xAB:0xB8] == b"DIFC HEADER  ",
+                        "DIM: Not a DIM file.")
+            media_byte, = struct.unpack('B255x', header)
+            if media_byte == 0:
+                format_str = 'pc98.2hd'
+            elif media_byte == 1:
+                # check the IPL to see if this is a Sharp disk
+                data = f.read(1024)
+                a, b, c = struct.unpack('BBB1021x', data)
+                if (a, b, c) == (0x60, 0x1e, 0x39):
+                    format_str = 'sharp.2hs'
+                else:
+                    format_str = 'pc98.2hs'
+            else:
+                raise error.Fatal("DIM: Unsupported format.")
 
         return format_str
 

--- a/src/greaseweazle/image/sharp2hs.py
+++ b/src/greaseweazle/image/sharp2hs.py
@@ -1,0 +1,15 @@
+# greaseweazle/image/sharp2d.py
+#
+# Written & released by Keir Fraser <keir.xen@gmail.com>
+#
+# This is free and unencumbered software released into the public domain.
+# See the file COPYING for more details, or visit <http://unlicense.org>.
+
+from greaseweazle.image.img import IMG
+
+class SHARP2HS(IMG):
+    default_format = 'sharp.2hs'
+
+# Local variables:
+# python-indent: 4
+# End:


### PR DESCRIPTION
Support was previously added (in #245) for 9-sector images on X68K and PC-98, but the Sharp variant is actually a little different; sector numbering starts from 10, except for the first sector of side 0, track 0, where r=1 in order to allow the boot ROM to find the IPL. Unfortunately, most images in this format are either DIM or a raw sector image, neither of which encode the sector numbers. This change adds a new variant of the 2HS format to accomplish this, and detects it in the DIM loader by looking for a 9SCFMT IPL header. The most invasive change is a new argument in ibm.py that allows for passing a list of sector numbers so that we can deal with the discontinuity on track 0.0.